### PR TITLE
✨ Adds Lutron Certificate add-on

### DIFF
--- a/.hassio-addons.yml
+++ b/.hassio-addons.yml
@@ -57,6 +57,10 @@ addons:
     repository: hassio-addons/addon-lovelace-migration
     target: lovelace-migration
     image: hassioaddons/lovelace-migration
+  lutron-cert:
+    repository: hassio-addons/addon-lutron-cert
+    target: lutron-cert
+    image: hassioaddons/lutron-cert
   node-red:
     repository: hassio-addons/addon-node-red
     target: node-red


### PR DESCRIPTION
# Proposed Changes

> This PR will add the [Lutron Certificate](https://github.com/hassio-addons/addon-lutron-cert) add-on to the beta repository.

## Related Issues

> N/A