### PR TITLE
Add ESPHome to community addons

### DIFF
--- a/.hassio-addons.yml
+++ b/.hassio-addons.yml
@@ -33,6 +33,10 @@ addons:
     repository: hassio-addons/addon-chrony
     target: chrony
     image: hassioaddons/chrony-{arch}
+  esphome:
+    repository: esphome/hassio
+    target: esphome-beta
+    image: esphome/esphome-hassio-{arch}
   example:
     repository: hassio-addons/addon-example
     target: example


### PR DESCRIPTION
# Proposed Changes

Add ESPHome to the community addons :sparkles:

The repository is located here: https://github.com/esphome/hassio

Tested with a private repository and the config

```yaml
channel: beta
addons:
  esphome:
    repository: esphome/hassio
    target: esphome-beta
    image: esphome/esphome-hassio-{arch}
```

See also https://github.com/hassio-addons/repository/pull/193

## Related Issues

None


<blockquote><img src="https://avatars3.githubusercontent.com/u/45919759?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicons/favicon.svg" height="14"> GitHub</div><div><strong><a href="https://github.com/esphome/hassio">esphome/hassio</a></strong></div><div>ESPHome Hass.io addon files. Contribute to esphome/hassio development by creating an account on GitHub.</div></blockquote>