### PR TITLE
Update esphome add-on configuration for Supervisor 2021.2

### DIFF
--- a/esphome/config.json
+++ b/esphome/config.json
@@ -5,12 +5,9 @@
     "aarch64"
   ],
   "auth_api": true,
-  "auto_uart": true,
-  "boot": "auto",
+  "uart": true,
   "description": "Beta version of ESPHome Hass.io add-on.",
   "hassio_api": true,
-  "hassio_role": "default",
-  "homeassistant_api": false,
   "host_network": true,
   "image": "esphome/esphome-hassio-{arch}",
   "ingress": true,
@@ -20,7 +17,6 @@
     "config:rw"
   ],
   "name": "ESPHome (beta)",
-  "options": {},
   "panel_icon": "mdi:chip",
   "ports": {
     "6052/tcp": null
@@ -40,8 +36,6 @@
   },
   "slug": "esphome-beta",
   "stage": "experimental",
-  "startup": "application",
   "url": "https://beta.esphome.io/",
-  "version": "1.16.0b8",
-  "webui": "http://[HOST]:[PORT:6052]"
+  "version": "1.16.0"
 }


### PR DESCRIPTION
# Proposed Changes

Update esphome add-on configuration for Supervisor 2021.2

See this PR: 
https://github.com/esphome/hassio/pull/17

## Related Issues

None

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/