### PR TITLE
Update esphome to 2021.12.3

### DIFF
--- a/esphome/config.json
+++ b/esphome/config.json
@@ -39,5 +39,5 @@
   "stage": "experimental",
   "uart": true,
   "url": "https://beta.esphome.io/",
-  "version": "2021.12.2"
+  "version": "2021.12.3"
 }


### PR DESCRIPTION
# Proposed Changes

Update esphome to 2021.12.3, since version 2021.12.2 was broken on hassio systems

## Related Issues

https://github.com/esphome/issues/issues/2874