### PR TITLE
✨ Add Syncthing

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -121,6 +121,10 @@ apps:
     repository: hassio-addons/addon-prowlarr
     target: prowlarr
     image: ghcr.io/hassio-addons/prowlarr/{arch}
+  syncthing:
+    repository: hassio-addons/app-syncthing
+    target: syncthing
+    image: ghcr.io/hassio-addons/syncthing
   tailscale:
     repository: hassio-addons/app-tailscale
     target: tailscale


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the Syncthing app to the beta store.

Syncthing is a continuous file synchronization program. The app has been modernized in [hassio-addons/app-syncthing](https://github.com/hassio-addons/app-syncthing): it now runs Syncthing v2.1.3 on `ghcr.io/hassio-addons/base` for aarch64 and amd64, uses s6-rc v3, and serves its web interface through NGINX so Ingress works. CI is green and the multi-arch image is published to `ghcr.io/hassio-addons/syncthing`.

**Please do not merge until a non-draft release of `app-syncthing` exists.** The repository updater skips draft releases, and its commit-SHA fallback only applies to the edge channel. Without a published release `latest_commit` stays `None`, and the updater dereferences it while loading the app config, which would abort the run for every app in this channel, not just Syncthing. `app-syncthing` currently has only a draft `v0.0.1`.

Edge is already covered by hassio-addons/repository-edge#78.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

- hassio-addons/repository-edge#78

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Syncthing as an available app.
  * Configured the app to use the Syncthing image and repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->