### PR TITLE
:sparkles: Add VictoriaMetrics to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -165,6 +165,10 @@ apps:
     repository: hassio-addons/app-uptime-kuma
     target: uptime-kuma
     image: ghcr.io/hassio-addons/uptime-kuma
+  victoriametrics:
+    repository: hassio-addons/app-victoriametrics
+    target: victoriametrics
+    image: ghcr.io/hassio-addons/victoriametrics
   vscode:
     repository: hassio-addons/addon-vscode
     target: vscode


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new VictoriaMetrics app to the store.

VictoriaMetrics is a fast and resource efficient time series database. It speaks the Prometheus query language and API, giving Home Assistant a home for long term metrics that the recorder is not built to keep, and a data source for Grafana.

The app can collect from Home Assistant either by scraping the Prometheus integration through the Supervisor, or by receiving what the InfluxDB integration pushes to it. It builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-victoriametrics

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VictoriaMetrics as an available app.
  * Configured the app to use its published container image and source repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->