### PR TITLE
:sparkles: Add Mealie to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -73,6 +73,10 @@ apps:
     repository: hassio-addons/addon-lidarr
     target: lidarr
     image: ghcr.io/hassio-addons/lidarr/{arch}
+  mealie:
+    repository: hassio-addons/app-mealie
+    target: mealie
+    image: ghcr.io/hassio-addons/mealie
   motioneye:
     repository: hassio-addons/addon-motioneye
     target: motioneye


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new Mealie app to the store.

Mealie is a self-hosted recipe manager and meal planner. It pulls a recipe off a page you point it at, keeps the ingredients and steps and drops the rest, turns a week of those into a meal plan, and adds up the plan into a shopping list. Home Assistant has an integration for it, so the plan and the lists can sit on a dashboard.

It runs behind Ingress, which took some doing: Mealie states it does not support being served on a sub-path, so the frontend is built from source here with two patches that read the path Ingress hands out, and NGINX writes that path into the page per request. The panel was checked in a real browser across eighteen routes, and direct access on port 9000 still behaves the same, which is also how the Home Assistant integration reaches it.

It builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-mealie

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

**Blocked until `v0.0.1` is released.** This PR is a draft on purpose. The
repository updater skips draft releases, and outside the edge channel it has no
commit to fall back on, so merging before the release is published would leave
this channel's update run without a version to build from. Ready to go the
moment the release is out.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mealie to the available app catalog.
  * Configured the app to use its designated repository and container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->