### PR TITLE
:sparkles: Add Homebox to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -69,6 +69,10 @@ apps:
     repository: hassio-addons/app-grocy
     target: grocy
     image: ghcr.io/hassio-addons/grocy
+  homebox:
+    repository: hassio-addons/app-homebox
+    target: homebox
+    image: ghcr.io/hassio-addons/homebox
   influxdb:
     repository: hassio-addons/addon-influxdb
     target: influxdb


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new Homebox app to the store.

Opened as a draft on purpose. Homebox goes into edge first, and this one is here for when it is ready to move up a channel.

Homebox is an inventory system for the things in a house. Items live in locations, locations nest inside each other, and anything can carry labels, a photo, the receipt, the manual, a serial number, a warranty date and whatever custom fields suit it. It keeps maintenance logs against an item, so the boiler service and the lawnmower blade change have somewhere to live, and it prints sheets of QR code labels to stick on the boxes themselves. The point of all of it is that "which box in the loft has the camping stove in it" becomes a search rather than an afternoon.

Alpine, and built entirely from source. The frontend is a Nuxt 3 SPA that the Go backend serves out of its own executable, so both build stages are pinned to `${BUILDPLATFORM}`: the JavaScript is the same whatever it was built on, and Go cross-compiles, so an aarch64 image never runs a toolchain under emulation. SQLite only, through `modernc.org/sqlite`, so there is no CGO anywhere in the stack.

Neither of the artifacts upstream publishes was usable. Their GitHub release binaries are glibc linked, which rules out Alpine, and their own image is Alpine but carries an unpatched frontend, which rules out Ingress. Since the frontend has to be built here anyway, building the backend alongside it costs one stage and buys control over the build flags.

One of those flags earns its comment in the Dockerfile. Homebox reaches for `libwebp`, `libavif`, `libheif` and `libjxl` by name at runtime through purego rather than linking them, which leaves the binary asking for a dynamic loader despite `CGO_ENABLED=0`. Building natively, Go writes down the loader of the machine it ran on; cross-compiling, it falls back to the one glibc uses, and `/lib/ld-linux-aarch64.so.1` does not exist on Alpine. The build therefore names the interpreter explicitly, with `-ldflags "-I /lib/ld-musl-aarch64.so.1"`. Without it the amd64 build is green and the aarch64 image fails at exec with a bare "not found", which is much cheaper to find here than in somebody's loft.

Ingress needed two patches, and the first is smaller than it had any right to be. Homebox builds every REST call and every attachment URL through one `route()` helper that reads a single prefix, and upstream already exports `overrideParts()` to change it, so a plugin calling that with the path Ingress handed out moves the entire API surface in one line. None of the `fetch`, `XMLHttpRequest` and image `src` interception the Mealie app has to carry for the same job was needed here.

The second patch covers the addresses the router never sees. The WebSocket carrying server events is assembled by hand from `window.location.host`, and nothing can intercept a `new WebSocket()`. The auth middleware stored `window.location.pathname` and handed it to `navigateTo()`, which prepends the base URL again, so under Ingress a session timeout sent you to the path twice over. Three `pathname === "/"` guards, one of them the loop breaker in the tenant 403 handler, never match under a prefix. Then the OIDC redirect, a raw anchor in the item table, the two collection dialogs that assign to `window.location.href`, and the base address the QR labels are built from. NGINX writes the Ingress path into the page per request and Nuxt reads it back at runtime, which is four values in the small document Nuxt bootstraps from; the megabytes of JavaScript behind them are never touched.

The PWA is switched off, through `pwa.disable: true` rather than by removing the module, so it stays a one line diff across version bumps. A service worker registered under an Ingress path has a scope with a session token in it and a manifest describing an app that lives at the site root, and a stale one caching an app that is not where it thinks it is goes wrong in ways that are tedious to clear. Direct access is the way to install it on a phone.

Two runtime details worth knowing. Homebox panics at startup without `HBOX_AUTH_API_KEY_PEPPER` of at least 32 bytes, and rotating it invalidates every API key ever issued, so the init generates one into `/data` and keeps it there. And `TRUST_PROXY` is on, because everything arrives through the NGINX in front of it: without it the rate limiting on the login form sees every attempt as coming from loopback, and one person mistyping their password would lock out the whole house.

Verified end to end against the built image. Over Ingress all four rewrites land and nothing in the served document is left addressed from the site root; assets, `set-theme.js` and the API all answer 200 through the panel, a deep SPA route falls back to index with the rewrites intact, and the WebSocket upgrade returns 101 through NGINX. Registration, login and an authenticated call all work through the prefix. The shipped bundle was checked to contain the patched WebSocket URL and the `overrideParts()` call, so both patches are demonstrably in the build rather than merely applied cleanly. Every one of the twenty `HBOX_*` variables the app sets was checked against Homebox's own flag list. The aarch64 binary was run under emulation on Alpine, where it starts and serves the API. hadolint, yamllint and shellcheck are clean.

It builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-homebox

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
